### PR TITLE
Fix task failure/success output manipulation

### DIFF
--- a/k8s-agent/src/k8s/pods.rs
+++ b/k8s-agent/src/k8s/pods.rs
@@ -129,13 +129,8 @@ async fn get_pod_output(mut attached: AttachedProcess) -> Result<String> {
 
     debug!("Waiting for process to finish");
     let join_lines = attached.join().await.map_or_else(
-        |_| "".to_owned(),
-        |err| {
-            format!(
-                "An error has occurred while waiting for runner pod to finish: {:?}\n\n",
-                err
-            )
-        },
+        |err| format!("An error has occurred while waiting for runner pod to finish: {err:?}\n\n",),
+        |_| Default::default(),
     );
 
     Ok(join_lines + &lines.join(""))


### PR DESCRIPTION
The code used the map_or_else with the parameters in the wrong order (success handling was were error handling should have been), causing all tasks to end with "failure: ()" although they succeeded