### PR TITLE
Define /api/v2 routes using macros

### DIFF
--- a/api/src/routes/v1/auth.rs
+++ b/api/src/routes/v1/auth.rs
@@ -15,12 +15,4 @@ async fn me(identity: ApiIdentity) -> ApiResult {
 
 pub fn config(cfg: &mut web::ServiceConfig) {
     cfg.route("/me", web::get().to(me));
-    cfg.route(
-        "/google",
-        web::get().to(super::super::v2::auth::google_login_info),
-    );
-    cfg.route(
-        "/google/callback",
-        web::post().to(super::super::v2::auth::google_login_callback),
-    );
 }

--- a/api/src/routes/v2/deployment_resource_types.rs
+++ b/api/src/routes/v2/deployment_resource_types.rs
@@ -1,9 +1,10 @@
 use crate::result::ApiResult;
-use actix_web::{web, HttpResponse};
+use actix_web::{get, web, HttpResponse};
 use platz_auth::ApiIdentity;
 use platz_db::{DeploymentResourceType, DeploymentResourceTypeFilters};
 use uuid::Uuid;
 
+#[get("/deployment-resource-types")]
 async fn get_all(
     _identity: ApiIdentity,
     filters: web::Query<DeploymentResourceTypeFilters>,
@@ -11,11 +12,7 @@ async fn get_all(
     Ok(HttpResponse::Ok().json(DeploymentResourceType::all_filtered(filters.into_inner()).await?))
 }
 
-async fn get(_identity: ApiIdentity, id: web::Path<Uuid>) -> ApiResult {
+#[get("/deployment-resource-types/{id}")]
+async fn get_one(_identity: ApiIdentity, id: web::Path<Uuid>) -> ApiResult {
     Ok(HttpResponse::Ok().json(DeploymentResourceType::find(id.into_inner()).await?))
-}
-
-pub fn config(cfg: &mut web::ServiceConfig) {
-    cfg.route("", web::get().to(get_all));
-    cfg.route("/{id}", web::get().to(get));
 }

--- a/api/src/routes/v2/deployment_resources.rs
+++ b/api/src/routes/v2/deployment_resources.rs
@@ -1,5 +1,5 @@
 use crate::result::ApiResult;
-use actix_web::{web, HttpResponse};
+use actix_web::{delete, get, post, put, web, HttpResponse};
 use futures::future::try_join_all;
 use platz_auth::ApiIdentity;
 use platz_db::{
@@ -10,6 +10,7 @@ use platz_db::{
 use serde_json::json;
 use uuid::Uuid;
 
+#[get("/deployment-resources")]
 async fn get_all(
     _identity: ApiIdentity,
     filters: web::Query<DeploymentResourceFilters>,
@@ -25,7 +26,8 @@ async fn get_all(
     Ok(HttpResponse::Ok().json(result))
 }
 
-async fn get(_identity: ApiIdentity, id: web::Path<Uuid>) -> ApiResult {
+#[get("/deployment-resources/{id}")]
+async fn get_one(_identity: ApiIdentity, id: web::Path<Uuid>) -> ApiResult {
     Ok(HttpResponse::Ok().json(
         DeploymentResource::find(id.into_inner())
             .await?
@@ -34,6 +36,7 @@ async fn get(_identity: ApiIdentity, id: web::Path<Uuid>) -> ApiResult {
     ))
 }
 
+#[post("/deployment-resources")]
 async fn create(
     _identity: ApiIdentity,
     new_resource: web::Json<NewDeploymentResource>,
@@ -44,6 +47,7 @@ async fn create(
     Ok(HttpResponse::Created().json(resource))
 }
 
+#[put("/deployment-resources/{id}")]
 async fn update(
     identity: ApiIdentity,
     id: web::Path<Uuid>,
@@ -100,6 +104,7 @@ async fn update(
     Ok(HttpResponse::Ok().json(new_resource))
 }
 
+#[delete("/deployment-resources/{id}")]
 async fn delete(_identity: ApiIdentity, id: web::Path<Uuid>) -> ApiResult {
     let resource = DeploymentResource::find(id.into_inner()).await?;
     if !resource.exists {
@@ -118,12 +123,4 @@ async fn delete(_identity: ApiIdentity, id: web::Path<Uuid>) -> ApiResult {
     .await?;
 
     Ok(HttpResponse::NoContent().finish())
-}
-
-pub fn config(cfg: &mut web::ServiceConfig) {
-    cfg.route("", web::get().to(get_all));
-    cfg.route("/{id}", web::get().to(get));
-    cfg.route("", web::post().to(create));
-    cfg.route("/{id}", web::put().to(update));
-    cfg.route("/{id}", web::delete().to(delete));
 }

--- a/api/src/routes/v2/deployment_tasks.rs
+++ b/api/src/routes/v2/deployment_tasks.rs
@@ -1,5 +1,5 @@
 use crate::result::ApiResult;
-use actix_web::{web, HttpResponse};
+use actix_web::{get, post, web, HttpResponse};
 use platz_auth::ApiIdentity;
 use platz_db::{
     DbError, DbTableOrDeploymentResource, Deployment, DeploymentTask, DeploymentTaskExtraFilters,
@@ -10,6 +10,7 @@ use serde::Deserialize;
 use serde_json::json;
 use uuid::Uuid;
 
+#[get("/deployment-tasks")]
 async fn get_all(
     _identity: ApiIdentity,
     filters: web::Query<DeploymentTaskFilters>,
@@ -20,7 +21,8 @@ async fn get_all(
     ))
 }
 
-async fn get(_identity: ApiIdentity, id: web::Path<Uuid>) -> ApiResult {
+#[get("/deployment-tasks/{id}")]
+async fn get_one(_identity: ApiIdentity, id: web::Path<Uuid>) -> ApiResult {
     Ok(HttpResponse::Ok().json(DeploymentTask::find(id.into_inner()).await?))
 }
 
@@ -30,6 +32,7 @@ pub struct ApiNewDeploymentTask {
     pub operation: DeploymentTaskOperation,
 }
 
+#[post("/deployment-tasks")]
 async fn create(identity: ApiIdentity, task: web::Json<ApiNewDeploymentTask>) -> ApiResult {
     let task = task.into_inner();
 
@@ -100,10 +103,4 @@ async fn create(identity: ApiIdentity, task: web::Json<ApiNewDeploymentTask>) ->
                 )
         })),
     })
-}
-
-pub fn config(cfg: &mut web::ServiceConfig) {
-    cfg.route("", web::get().to(get_all));
-    cfg.route("/{id}", web::get().to(get));
-    cfg.route("", web::post().to(create));
 }

--- a/api/src/routes/v2/helm_charts.rs
+++ b/api/src/routes/v2/helm_charts.rs
@@ -1,9 +1,10 @@
 use crate::result::ApiResult;
-use actix_web::{web, HttpResponse};
+use actix_web::{get, web, HttpResponse};
 use platz_auth::ApiIdentity;
 use platz_db::{HelmChart, HelmChartExtraFilters, HelmChartFilters};
 use uuid::Uuid;
 
+#[get("/helm-charts")]
 async fn get_all(
     _identity: ApiIdentity,
     filters: web::Query<HelmChartFilters>,
@@ -13,11 +14,7 @@ async fn get_all(
         .json(HelmChart::all_filtered(filters.into_inner(), extra_filters.into_inner()).await?))
 }
 
-async fn get(_identity: ApiIdentity, id: web::Path<Uuid>) -> ApiResult {
+#[get("/helm-charts/{id}")]
+async fn get_one(_identity: ApiIdentity, id: web::Path<Uuid>) -> ApiResult {
     Ok(HttpResponse::Ok().json(HelmChart::find(id.into_inner()).await?))
-}
-
-pub fn config(cfg: &mut web::ServiceConfig) {
-    cfg.route("", web::get().to(get_all));
-    cfg.route("/{id}", web::get().to(get));
 }

--- a/api/src/routes/v2/helm_registries.rs
+++ b/api/src/routes/v2/helm_registries.rs
@@ -1,18 +1,21 @@
 use crate::permissions::verify_site_admin;
 use crate::result::ApiResult;
-use actix_web::{web, HttpResponse};
+use actix_web::{get, put, web, HttpResponse};
 use platz_auth::ApiIdentity;
 use platz_db::{HelmRegistry, HelmRegistryFilters, UpdateHelmRegistry};
 use uuid::Uuid;
 
+#[get("/helm-registries")]
 async fn get_all(_identity: ApiIdentity, filters: web::Query<HelmRegistryFilters>) -> ApiResult {
     Ok(HttpResponse::Ok().json(HelmRegistry::all_filtered(filters.into_inner()).await?))
 }
 
-async fn get(_identity: ApiIdentity, id: web::Path<Uuid>) -> ApiResult {
+#[get("/helm-registries/{id}")]
+async fn get_one(_identity: ApiIdentity, id: web::Path<Uuid>) -> ApiResult {
     Ok(HttpResponse::Ok().json(HelmRegistry::find(id.into_inner()).await?))
 }
 
+#[put("/helm-registries/{id}")]
 async fn update(
     identity: ApiIdentity,
     id: web::Path<Uuid>,
@@ -22,10 +25,4 @@ async fn update(
     let id = id.into_inner();
     let data = data.into_inner();
     Ok(HttpResponse::Ok().json(data.save(id).await?))
-}
-
-pub fn config(cfg: &mut web::ServiceConfig) {
-    cfg.route("", web::get().to(get_all));
-    cfg.route("/{id}", web::get().to(get));
-    cfg.route("/{id}", web::put().to(update));
 }

--- a/api/src/routes/v2/k8s_resources.rs
+++ b/api/src/routes/v2/k8s_resources.rs
@@ -1,18 +1,15 @@
 use crate::result::ApiResult;
-use actix_web::{web, HttpResponse};
+use actix_web::{get, web, HttpResponse};
 use platz_auth::ApiIdentity;
 use platz_db::{K8sResource, K8sResourceFilters};
 use uuid::Uuid;
 
+#[get("/k8s-resources")]
 async fn get_all(_identity: ApiIdentity, filters: web::Query<K8sResourceFilters>) -> ApiResult {
     Ok(HttpResponse::Ok().json(K8sResource::all_filtered(filters.into_inner()).await?))
 }
 
-async fn get(_identity: ApiIdentity, id: web::Path<Uuid>) -> ApiResult {
+#[get("/k8s-resources/{id}")]
+async fn get_one(_identity: ApiIdentity, id: web::Path<Uuid>) -> ApiResult {
     Ok(HttpResponse::Ok().json(K8sResource::find(id.into_inner()).await?))
-}
-
-pub fn config(cfg: &mut web::ServiceConfig) {
-    cfg.route("", web::get().to(get_all));
-    cfg.route("/{id}", web::get().to(get));
 }

--- a/api/src/routes/v2/mod.rs
+++ b/api/src/routes/v2/mod.rs
@@ -1,4 +1,4 @@
-pub mod auth;
+mod auth;
 mod deployment_permissions;
 mod deployment_resource_types;
 mod deployment_resources;
@@ -12,45 +12,70 @@ mod helm_tag_formats;
 mod k8s_clusters;
 mod k8s_resources;
 mod secrets;
+mod server;
 mod user_tokens;
 mod users;
 mod ws;
 
-use actix_web::{web, HttpResponse};
-use serde::Serialize;
-
-use crate::result::ApiResult;
+use actix_web::web;
 
 pub fn config(cfg: &mut web::ServiceConfig) {
-    cfg.route("/self", web::get().to(self_route));
-    cfg.service(web::scope("/auth").configure(auth::config));
-    cfg.service(web::scope("/deployment-permissions").configure(deployment_permissions::config));
-    cfg.service(
-        web::scope("/deployment-resource-types").configure(deployment_resource_types::config),
-    );
-    cfg.service(web::scope("/deployment-resources").configure(deployment_resources::config));
-    cfg.service(web::scope("/deployment-tasks").configure(deployment_tasks::config));
-    cfg.service(web::scope("/deployments").configure(deployments::config));
-    cfg.service(web::scope("/env-user-permissions").configure(env_user_permissions::config));
-    cfg.service(web::scope("/envs").configure(envs::config));
-    cfg.service(web::scope("/helm-charts").configure(helm_charts::config));
-    cfg.service(web::scope("/helm-registries").configure(helm_registries::config));
-    cfg.service(web::scope("/helm-tag-formats").configure(helm_tag_formats::config));
-    cfg.service(web::scope("/k8s-clusters").configure(k8s_clusters::config));
-    cfg.service(web::scope("/k8s-resources").configure(k8s_resources::config));
-    cfg.service(web::scope("/secrets").configure(secrets::config));
-    cfg.service(web::scope("/user-tokens").configure(user_tokens::config));
-    cfg.service(web::scope("/users").configure(users::config));
+    cfg.service(auth::me);
+    cfg.service(auth::start_google_login);
+    cfg.service(auth::finish_google_login);
+    cfg.service(deployment_permissions::get_all);
+    cfg.service(deployment_permissions::get_one);
+    cfg.service(deployment_permissions::create);
+    cfg.service(deployment_permissions::delete);
+    cfg.service(deployment_resource_types::get_all);
+    cfg.service(deployment_resource_types::get_one);
+    cfg.service(deployment_resources::get_all);
+    cfg.service(deployment_resources::get_one);
+    cfg.service(deployment_resources::create);
+    cfg.service(deployment_resources::update);
+    cfg.service(deployment_resources::delete);
+    cfg.service(deployment_tasks::get_all);
+    cfg.service(deployment_tasks::get_one);
+    cfg.service(deployment_tasks::create);
+    cfg.service(deployments::get_all);
+    cfg.service(deployments::get_one);
+    cfg.service(deployments::create);
+    cfg.service(deployments::update);
+    cfg.service(deployments::delete);
+    cfg.service(env_user_permissions::get_all);
+    cfg.service(env_user_permissions::get_one);
+    cfg.service(env_user_permissions::create);
+    cfg.service(env_user_permissions::delete);
+    cfg.service(envs::get_all);
+    cfg.service(envs::get_one);
+    cfg.service(envs::create);
+    cfg.service(envs::update);
+    cfg.service(helm_charts::get_all);
+    cfg.service(helm_charts::get_one);
+    cfg.service(helm_registries::get_all);
+    cfg.service(helm_registries::get_one);
+    cfg.service(helm_registries::update);
+    cfg.service(helm_tag_formats::get_all);
+    cfg.service(helm_tag_formats::get_one);
+    cfg.service(helm_tag_formats::create);
+    cfg.service(helm_tag_formats::delete);
+    cfg.service(k8s_clusters::get_all);
+    cfg.service(k8s_resources::get_all);
+    cfg.service(k8s_clusters::update);
+    cfg.service(k8s_clusters::delete);
+    cfg.service(k8s_resources::get_one);
+    cfg.service(secrets::get_all);
+    cfg.service(secrets::get_one);
+    cfg.service(secrets::create);
+    cfg.service(secrets::update);
+    cfg.service(secrets::delete);
+    cfg.service(server::get_one);
+    cfg.service(user_tokens::get_all);
+    cfg.service(user_tokens::get_one);
+    cfg.service(user_tokens::create);
+    cfg.service(user_tokens::delete);
+    cfg.service(users::get_all);
+    cfg.service(users::get_one);
+    cfg.service(users::update);
     cfg.service(web::scope("/ws").configure(ws::config));
-}
-
-#[derive(Debug, Serialize)]
-pub struct SelfInfo {
-    pub version: String,
-}
-
-async fn self_route() -> ApiResult {
-    Ok(HttpResponse::Ok().json(SelfInfo {
-        version: std::env!("PLATZ_BACKEND_VERSION").to_string(),
-    }))
 }

--- a/api/src/routes/v2/server.rs
+++ b/api/src/routes/v2/server.rs
@@ -1,0 +1,15 @@
+use crate::result::ApiResult;
+use actix_web::{get, HttpResponse};
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct ServerInfo {
+    pub version: String,
+}
+
+#[get("/server")]
+async fn get_one() -> ApiResult {
+    Ok(HttpResponse::Ok().json(ServerInfo {
+        version: std::env!("PLATZ_BACKEND_VERSION").to_string(),
+    }))
+}

--- a/api/src/routes/v2/users.rs
+++ b/api/src/routes/v2/users.rs
@@ -1,19 +1,22 @@
 use crate::permissions::verify_site_admin;
 use crate::result::ApiResult;
-use actix_web::{web, HttpResponse};
+use actix_web::{get, put, web, HttpResponse};
 use platz_auth::ApiIdentity;
 use platz_db::{UpdateUser, User, UserFilters};
 use serde_json::json;
 use uuid::Uuid;
 
+#[get("/users")]
 async fn get_all(_identity: ApiIdentity, filters: web::Query<UserFilters>) -> ApiResult {
     Ok(HttpResponse::Ok().json(User::all_filtered(filters.into_inner()).await?))
 }
 
-async fn get(_identity: ApiIdentity, id: web::Path<Uuid>) -> ApiResult {
+#[get("/users/{id}")]
+async fn get_one(_identity: ApiIdentity, id: web::Path<Uuid>) -> ApiResult {
     Ok(HttpResponse::Ok().json(User::find(id.into_inner()).await?))
 }
 
+#[put("/users/{id}")]
 async fn update(
     identity: ApiIdentity,
     id: web::Path<Uuid>,
@@ -28,10 +31,4 @@ async fn update(
     } else {
         Ok(HttpResponse::Ok().json(update.into_inner().save(id).await?))
     }
-}
-
-pub fn config(cfg: &mut web::ServiceConfig) {
-    cfg.route("", web::get().to(get_all));
-    cfg.route("/{id}", web::get().to(get));
-    cfg.route("/{id}", web::put().to(update));
 }


### PR DESCRIPTION
Adding OpenAPI only contains additions and shouldn't change any behavior, this PR contains only the important changes so it's easier to review:
- Move /api/v2/self -> /api/v2/server
- Remove /api/v1/google routes