### PR TITLE
Fix aggregated metric updating

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2859,6 +2859,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "strum",
  "thiserror",
  "tokio",
  "tokio-stream",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -21,6 +21,7 @@ prometheus = "0.13.3"
 regex = "1.5.6"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"
+strum = "0.24.1"
 thiserror = "1"
 tokio = {version = "1", features = ["full"]}
 tokio-stream = {version = "0.1.5", features = ["sync"]}

--- a/db/src/schema/deployment.rs
+++ b/db/src/schema/deployment.rs
@@ -18,7 +18,7 @@ use platz_chart_ext::actions::{
 use platz_chart_ext::{ChartExtIngressHostnameFormat, UiSchema};
 use serde::{Deserialize, Serialize};
 use strum::AsRefStr;
-use strum::{Display, EnumString};
+use strum::{Display, EnumIter, EnumString};
 use url::Url;
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -50,6 +50,7 @@ table! {
     Eq,
     Serialize,
     Deserialize,
+    EnumIter,
     EnumString,
     AsRefStr,
     Display,

--- a/db/src/schema/deployment_task.rs
+++ b/db/src/schema/deployment_task.rs
@@ -14,7 +14,7 @@ use diesel_filter::{DieselFilter, Paginate};
 use diesel_json::Json;
 use platz_chart_ext::resource_types::ChartExtResourceType;
 use serde::{Deserialize, Serialize};
-use strum::{AsRefStr, Display, EnumString};
+use strum::{AsRefStr, Display, EnumIter, EnumString};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -44,6 +44,7 @@ table! {
     Serialize,
     Deserialize,
     EnumString,
+    EnumIter,
     AsRefStr,
     Display,
     DieselEnum,


### PR DESCRIPTION
Previously, only task and deployment statuses *which appeared in the distinct query* got reported as counter metrics. This commit changes it to report all statuses, regardless of if they exist in the query or not.