### PR TITLE
Putting platz-chart-ext dep in workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,7 @@ resolver = "2"
 
 [profile.release]
 debug = true
+
+[workspace.dependencies.platz-chart-ext]
+features = ["utoipa"]
+version = "0.5.7"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -16,7 +16,7 @@ humantime = "2.1.0"
 itertools = "0.11.0"
 lazy_static = "1.4.0"
 log = "0.4.19"
-platz-chart-ext = {version = "0.5.7", features = ["utoipa"]}
+platz-chart-ext = {workspace = true}
 prometheus = "0.13.3"
 regex = "1.9.1"
 serde = {version = "1.0.171", features = ["derive"]}

--- a/chart-discovery/Cargo.toml
+++ b/chart-discovery/Cargo.toml
@@ -16,7 +16,7 @@ env_logger = "0.10.0"
 futures = "0.3.28"
 itertools = "0.11.0"
 log = "0.4.19"
-platz-chart-ext = "0.5.7"
+platz-chart-ext = {workspace = true}
 regex = "1.9.1"
 serde = {version = "1.0.171", features = ["derive"]}
 serde_json = "1.0.100"

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -15,7 +15,7 @@ itertools = "0.11.0"
 lazy_static = "1.4.0"
 log = "0.4.19"
 maplit = "1.0.2"
-platz-chart-ext = {version = "0.5.7", features = ["utoipa"]}
+platz-chart-ext = {workspace = true}
 postgres = "0.19.5"
 r2d2 = "0.8.10"
 rust_decimal = {version = "1.30.0", default-features = false, features = ["db-diesel-postgres"]}

--- a/k8s-agent/Cargo.toml
+++ b/k8s-agent/Cargo.toml
@@ -24,7 +24,7 @@ kube = {version = "0.83.0", default-features = false, features = ["client", "gzi
 lazy_static = "1.4.0"
 log = "0.4.19"
 maplit = "1.0.2"
-platz-chart-ext = "0.5.7"
+platz-chart-ext = {workspace = true}
 serde = {version = "1.0.171", features = ["derive"]}
 serde_json = "1.0.100"
 serde_yaml = "0.9.22"

--- a/resource-sync/Cargo.toml
+++ b/resource-sync/Cargo.toml
@@ -9,7 +9,7 @@ clap = {version = "4.3.11", features = ["derive"]}
 env_logger = "0.10.0"
 itertools = "0.11.0"
 log = "0.4.19"
-platz-chart-ext = "0.5.7"
+platz-chart-ext = {workspace = true}
 reqwest = {version = "0.11.18", default-features = false, features = ["rustls-tls", "json"]}
 serde = {version = "1.0.171", features = ["derive"]}
 serde_json = "1.0.100"

--- a/status-updates/Cargo.toml
+++ b/status-updates/Cargo.toml
@@ -11,7 +11,7 @@ env_logger = "0.10.0"
 futures = "0.3.28"
 futures-util = "0.3.28"
 log = "0.4.19"
-platz-chart-ext = "0.5.7"
+platz-chart-ext = {workspace = true}
 reqwest = {version = "0.11.18", default-features = false, features = ["rustls-tls", "json"]}
 serde = {version = "1.0.171", features = ["derive"]}
 serde_json = "1.0.100"


### PR DESCRIPTION
Since all crates use ../db and pass around structs from chart-ext, they practically depend on db's char-ext, with the utoipa feature turned on. Using from the workspace makes the dependency uniform (and when you temporarily point it to a local path for development, it's just one place to edit)