### PR TITLE
Status updates improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3196,6 +3196,7 @@ name = "platz-status-updates"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "futures",
  "platz-chart-ext",
  "platz-db",

--- a/status-updates/Cargo.toml
+++ b/status-updates/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [dependencies]
 anyhow = "1.0.87"
+clap = { version = "4.5.17", features = ["derive"] }
 futures = "0.3.30"
 platz-chart-ext = { workspace = true }
 reqwest = { version = "0.12.7", default-features = false, features = [

--- a/status-updates/src/events.rs
+++ b/status-updates/src/events.rs
@@ -15,6 +15,7 @@ pub async fn watch_deployments(tracker: StatusTracker) -> Result<()> {
         join_all(
             deploy_chunk
                 .iter()
+                .filter(|dep| dep.enabled)
                 .map(|deployment| tracker.add(deployment.clone())),
         )
         .await;


### PR DESCRIPTION
In case this PR will be merged, the deployment helm-chart will need to be changed as well, for using the heartbeat.
For example:
```
      containers:
        - name: status-updates
          securityContext:
            {{- toYaml .Values.securityContext | nindent 12 }}
          image: '{{- .Values.images.backend.repository }}:{{ .Values.images.backend.tag }}'
          imagePullPolicy: {{ .Values.images.backend.pullPolicy }}
          command:
            - /root/platz-status-updates
            - --heartbeat-file-path=/tmp/heartbeat
          livenessProbe:
            exec:
              command:
                - /bin/sh
                - '-c'
                - find /tmp/heartbeat -type f -newermt '5 minute ago' | grep -q -e '.'
            initialDelaySeconds: 120
            timeoutSeconds: 1
            periodSeconds: 60
            successThreshold: 1
            failureThreshold: 1
```