### PR TITLE
ci: parallelize image builds with tests; fix cargo-chef layer caching

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,14 @@ jobs:
   # One image build per architecture, on a native runner. We push by digest;
   # a final `merge` job stitches the two digests into a multi-arch manifest list.
   # Native arm64 runners avoid QEMU emulation, which dominated build time.
+  #
+  # This job does NOT depend on `test`: the test job compiles for the host gnu
+  # target while these build for musl, so they share no artifacts and gating
+  # would only serialize clippy+test ahead of the build for no reuse. Tests run
+  # concurrently instead; the `merge` job below re-gates on `test` so a tagged
+  # multi-arch image is never published when linting or tests fail.
   image:
     name: 🐳 Build (${{ matrix.platform }})
-    needs:
-      - test
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -132,6 +136,7 @@ jobs:
     if: github.event_name == 'push'
     needs:
       - image
+      - test
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-# Multi-stage build using cargo-chef for dep-only layer caching and per-arch
-# cache mounts so amd64 and arm64 don't fight over the same target dir.
+# Multi-stage build using cargo-chef so dependency compilation lands in a
+# dedicated layer that is only invalidated when the dependency graph
+# (recipe.json) changes. That layer is what CI restores from the GHA layer
+# cache (see `cache-to: type=gha,mode=max`, scoped per arch in the workflow),
+# so source-only changes skip recompiling dependencies.
 #
 # Drives the workspace into a static musl binary so the runtime image (alpine-
 # based platzio/base) doesn't need a libc. Architecture is selected via Docker
@@ -31,9 +34,14 @@ COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
 # ---------------------------------------------------------------------------
-# 3. builder — cook deps from the recipe, then build the workspace. The cooked
-# deps live in a buildkit cache mount keyed by TARGETARCH, so each architecture
-# keeps its own warm target dir across CI runs.
+# 3. builder — cook deps from the recipe, then build the workspace. The cook
+# step writes compiled deps (and downloaded crates) into the layer filesystem
+# — deliberately NOT a buildkit cache mount, which would be excluded from the
+# image layer and dropped between CI runs on fresh builders. Keeping them in
+# the layer lets Docker's layer cache capture the cook step; the workflow
+# exports it via `cache-to: type=gha,mode=max` scoped per arch. recipe.json
+# only changes when the dep graph changes, so source-only edits restore the
+# cook layer from cache and re-run just the final `cargo build`.
 # ---------------------------------------------------------------------------
 FROM chef AS builder
 ARG RELEASE_BUILD=1
@@ -49,10 +57,7 @@ RUN set -eux; \
     rustup target add "${target}"
 
 COPY --from=planner /build/recipe.json recipe.json
-RUN --mount=type=cache,id=platz-cargo-target-${TARGETARCH},target=/build/target,sharing=locked \
-    --mount=type=cache,id=platz-cargo-git,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,id=platz-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
-    set -eux; \
+RUN set -eux; \
     target="$(cat /target.txt)"; \
     if [ "${RELEASE_BUILD}" = "1" ]; then \
         cargo chef cook --release --target "${target}" --recipe-path recipe.json; \
@@ -61,10 +66,7 @@ RUN --mount=type=cache,id=platz-cargo-target-${TARGETARCH},target=/build/target,
     fi
 
 COPY . .
-RUN --mount=type=cache,id=platz-cargo-target-${TARGETARCH},target=/build/target,sharing=locked \
-    --mount=type=cache,id=platz-cargo-git,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,id=platz-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
-    set -eux; \
+RUN set -eux; \
     target="$(cat /target.txt)"; \
     if [ "${RELEASE_BUILD}" = "1" ]; then \
         cargo build --release --target "${target}"; \


### PR DESCRIPTION
## Why

Two structural inefficiencies in the backend release pipeline make CI slower than it needs to be. This addresses both.

## 1. Image builds were serialized behind clippy + tests

The `image` matrix declared `needs: test`, so neither arch build could start until the `test` job (`cargo clippy --release` + `cargo test --release`) finished. But the test job compiles for the **host gnu** target while the image builds compile for **musl** (`x86_64`/`aarch64-unknown-linux-musl`) — three different target triples that share **zero** compiled artifacts. So the gate added the entire clippy+test duration to the critical path with no reuse benefit.

**Change:** drop `needs: test` from `image` so tests and the two native-arch builds run **concurrently**. Critical path goes from `test + build` to roughly `max(test, build)`.

Correctness is preserved by re-gating where it matters: the `merge` job — which creates the published multi-arch tag — now `needs: [image, test]`, and `release` still depends on `merge`. So **no tagged image is ever published when linting or tests fail**. On a tag push the per-arch jobs may push *untagged* digests before tests finish, but those stay dangling and unreferenced unless `merge` runs.

## 2. cargo-chef was a no-op in CI (deps recompiled from scratch every run)

The `Dockerfile` builder stage mounted `/build/target` (and the cargo git/registry dirs) as BuildKit `type=cache` mounts. But:

- BuildKit cache mounts are **not** part of the image layer and are **not** exported by `cache-to: type=gha`.
- `setup-buildx-action` creates a fresh `docker-container` builder each run, so those mounts start **empty** every time.
- cargo-chef depends on the `cook` step's compiled deps being captured for reuse. On the common case (source changed, deps unchanged), the cook **layer** was a cache hit and got skipped — without repopulating the empty mount — so the final `cargo build` recompiled **every dependency from scratch**, on each arch, every run.

**Change:** remove the cache mounts so the `cook` step's output lands in the **layer filesystem**, where Docker's layer cache captures it and `cache-to: type=gha,mode=max` (already scoped per arch) persists it across runs. Now a source-only change restores the cook layer from cache and rebuilds only the workspace crates — which is the whole point of cargo-chef.

## Verification / caveats

- I can't measure Actions run timings or read build logs from where I'm working, so the timing claims are structural, not measured. The cache fix is verifiable from a build log: on a docs-only change, the cook step should now be `CACHED` instead of recompiling dependencies.
- The cook layer now carries the dependency `target/` dir, so the per-arch GHA caches grow. With two arch scopes this could approach the 10 GB repo cache budget; worth watching. Worst case (eviction) is no worse than today's effectively-cold builds.

Each concern is a separate commit if you'd prefer to take them independently.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BU7afKrXE7qV1PvJfJRVyv)_