### PR TITLE
Split CI into test, build, and release orchestrator workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,101 @@
+name: 🐳 Build
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_call:
+    inputs:
+      push:
+        description: Push images by digest after building
+        type: boolean
+        default: false
+
+env:
+  DOCKER_REPO: platzio/backend
+
+permissions:
+  contents: read
+
+# One image build per architecture, on a native runner. When called with
+# push:true we push by digest; the caller is responsible for assembling
+# the multi-arch manifest list. On pull_request we build only, to validate
+# the Dockerfile without publishing.
+#
+# Native arm64 runners avoid QEMU emulation, which dominated build time.
+jobs:
+  image:
+    name: 🐳 Build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: 🧷 Platform pair
+        run: |
+          platform="${{ matrix.platform }}"
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "${GITHUB_ENV}"
+
+      - name: 🛎️ Checkout
+        uses: actions/checkout@v5
+
+      - name: 🗽 Free disk space
+        uses: ShubhamTatvamasi/free-disk-space-action@master
+
+      - name: 🐳 Login to DockerHub
+        if: inputs.push
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: 🛠️ Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # PR validation: build the image but don't push. Cache scoped per arch so
+      # the two matrix entries don't clobber each other's GHA cache.
+      - name: 🐳 Build (PR validation)
+        if: ${{ !inputs.push }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          build-args: BASE_IMAGE=platzio/base:v8
+          platforms: ${{ matrix.platform }}
+          push: false
+          cache-from: type=gha,scope=build-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=build-${{ env.PLATFORM_PAIR }}
+
+      # Release path: build and push by digest. The caller assembles the final
+      # tagged manifest from the uploaded digest artifacts.
+      - name: 🐳 Build & push by digest
+        if: inputs.push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          build-args: BASE_IMAGE=platzio/base:v8
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.DOCKER_REPO }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=build-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=build-${{ env.PLATFORM_PAIR }}
+
+      - name: 📤 Export digest
+        if: inputs.push
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: 📦 Upload digest
+        if: inputs.push
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   DOCKER_REPO: platzio/backend
+  BASE_IMAGE: platzio/base:v8
 
 permissions:
   contents: read
@@ -42,45 +43,33 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> "${GITHUB_ENV}"
 
       - name: 🛎️ Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: 🗽 Free disk space
         uses: ShubhamTatvamasi/free-disk-space-action@master
 
       - name: 🐳 Login to DockerHub
         if: inputs.push
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: 🛠️ Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
-      # PR validation: build the image but don't push. Cache scoped per arch so
-      # the two matrix entries don't clobber each other's GHA cache.
-      - name: 🐳 Build (PR validation)
-        if: ${{ !inputs.push }}
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          build-args: BASE_IMAGE=platzio/base:v8
-          platforms: ${{ matrix.platform }}
-          push: false
-          cache-from: type=gha,scope=build-${{ env.PLATFORM_PAIR }}
-          cache-to: type=gha,mode=max,scope=build-${{ env.PLATFORM_PAIR }}
-
-      # Release path: build and push by digest. The caller assembles the final
-      # tagged manifest from the uploaded digest artifacts.
-      - name: 🐳 Build & push by digest
-        if: inputs.push
+      # On push:true we push by digest and the caller assembles the multi-arch
+      # manifest from the uploaded digests. On PR (push:false) we discard the
+      # output (type=cacheonly) — the build itself still validates the
+      # Dockerfile and warms the per-arch GHA cache.
+      - name: 🐳 Build
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
-          build-args: BASE_IMAGE=platzio/base:v8
+          build-args: BASE_IMAGE=${{ env.BASE_IMAGE }}
           platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.DOCKER_REPO }},push-by-digest=true,name-canonical=true,push=true
+          outputs: ${{ inputs.push && format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', env.DOCKER_REPO) || 'type=cacheonly' }}
           cache-from: type=gha,scope=build-${{ env.PLATFORM_PAIR }}
           cache-to: type=gha,mode=max,scope=build-${{ env.PLATFORM_PAIR }}
 
@@ -93,7 +82,7 @@ jobs:
 
       - name: 📦 Upload digest
         if: inputs.push
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,12 +18,6 @@ env:
 permissions:
   contents: read
 
-# One image build per architecture, on a native runner. When called with
-# push:true we push by digest; the caller is responsible for assembling
-# the multi-arch manifest list. On pull_request we build only, to validate
-# the Dockerfile without publishing.
-#
-# Native arm64 runners avoid QEMU emulation, which dominated build time.
 jobs:
   image:
     name: 🐳 Build (${{ matrix.platform }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: ⎈ Release Version
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     tags:
       - v**
@@ -15,141 +12,22 @@ permissions:
   contents: read
 
 jobs:
-  fmt:
-    name: 🎨 Check formatting
-    runs-on: ubuntu-latest
-    steps:
-      - name: 🛎️ Checkout
-        uses: actions/checkout@v5
-
-      - name: 🧰 Install rustfmt
-        run: rustup component add rustfmt
-
-      - name: 🎨 Cargo fmt
-        run: cargo fmt --all -- --check
-
   test:
-    name: 🧪 Run Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: 🛎️ Checkout
-        uses: actions/checkout@v5
+    name: 🧪 Test
+    uses: ./.github/workflows/test.yml
 
-      - name: 📦 Cargo version
-        id: cargo
-        run: |
-          echo "rustc=$(rustc --version)" >> "${GITHUB_OUTPUT}"
-
-      - name: 🪣 Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          key: ${{ steps.cargo.outputs.rustc }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ${{ steps.cargo.outputs.rustc }}
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-
-      - name: 📎 Cargo clippy
-        run: |
-          cargo clippy --release -- -D warnings
-
-      - name: 🔨 Cargo test
-        run: |
-          cargo test --release
-
-  # One image build per architecture, on a native runner. We push by digest;
-  # a final `merge` job stitches the two digests into a multi-arch manifest list.
-  # Native arm64 runners avoid QEMU emulation, which dominated build time.
-  #
-  # This job does NOT depend on `test`: the test job compiles for the host gnu
-  # target while these build for musl, so they share no artifacts and gating
-  # would only serialize clippy+test ahead of the build for no reuse. Tests run
-  # concurrently instead; the `merge` job below re-gates on `test` so a tagged
-  # multi-arch image is never published when linting or tests fail.
-  image:
-    name: 🐳 Build (${{ matrix.platform }})
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-latest
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-    steps:
-      - name: 🧷 Platform pair
-        run: |
-          platform="${{ matrix.platform }}"
-          echo "PLATFORM_PAIR=${platform//\//-}" >> "${GITHUB_ENV}"
-
-      - name: 🛎️ Checkout
-        uses: actions/checkout@v5
-
-      - name: 🗽 Free disk space
-        uses: ShubhamTatvamasi/free-disk-space-action@master
-
-      - name: 🐳 Login to DockerHub
-        if: github.event_name == 'push'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: 🛠️ Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      # PR validation: build the image but don't push. Cache scoped per arch so
-      # the two matrix entries don't clobber each other's GHA cache.
-      - name: 🐳 Build (PR validation)
-        if: github.event_name != 'push'
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          build-args: BASE_IMAGE=platzio/base:v8
-          platforms: ${{ matrix.platform }}
-          push: false
-          cache-from: type=gha,scope=build-${{ env.PLATFORM_PAIR }}
-          cache-to: type=gha,mode=max,scope=build-${{ env.PLATFORM_PAIR }}
-
-      # Tag push: build and push by digest. The merge job below assembles the
-      # final tagged manifest.
-      - name: 🐳 Build & push by digest
-        if: github.event_name == 'push'
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          build-args: BASE_IMAGE=platzio/base:v8
-          platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.DOCKER_REPO }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=build-${{ env.PLATFORM_PAIR }}
-          cache-to: type=gha,mode=max,scope=build-${{ env.PLATFORM_PAIR }}
-
-      - name: 📤 Export digest
-        if: github.event_name == 'push'
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - name: 📦 Upload digest
-        if: github.event_name == 'push'
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ env.PLATFORM_PAIR }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
+  build:
+    name: 🐳 Build
+    uses: ./.github/workflows/build.yml
+    with:
+      push: true
+    secrets: inherit
 
   merge:
     name: 🧬 Assemble manifest list
-    if: github.event_name == 'push'
     needs:
-      - image
       - test
+      - build
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
@@ -188,7 +66,6 @@ jobs:
 
   release:
     name: 🚀 Create Release
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs:
       - merge

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,20 +38,20 @@ jobs:
           echo "tag=${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
 
       - name: 📥 Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: 🐳 Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: 🛠️ Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: 🧬 Create manifest list and push
         working-directory: /tmp/digests
@@ -80,29 +80,9 @@ jobs:
             /root/platz-api openapi schema \
             > openapi.yaml
 
-      - name: ✨ Create release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          draft: true
-          tag_name: ${{ needs.merge.outputs.tag }}
-          release_name: ${{ needs.merge.outputs.tag }}
-
-      - name: 📦 Upload OpenAPI schema
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: openapi.yaml
-          asset_name: openapi.yaml
-          asset_content_type: application/vnd.oai.openapi
-
       - name: 🚀 Publish release
-        uses: StuYarrow/publish-release@v1.1.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v3
         with:
-          id: ${{ steps.create_release.outputs.id }}
+          tag_name: ${{ needs.merge.outputs.tag }}
+          name: ${{ needs.merge.outputs.tag }}
+          files: openapi.yaml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛎️ Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: 🧰 Install rustfmt
         run: rustup component add rustfmt
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛎️ Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: 📦 Cargo version
         id: cargo
@@ -36,7 +36,7 @@ jobs:
           echo "rustc=$(rustc --version)" >> "${GITHUB_OUTPUT}"
 
       - name: 🪣 Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           key: ${{ steps.cargo.outputs.rustc }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,55 @@
+name: 🧪 Test
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  fmt:
+    name: 🎨 Check formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛎️ Checkout
+        uses: actions/checkout@v5
+
+      - name: 🧰 Install rustfmt
+        run: rustup component add rustfmt
+
+      - name: 🎨 Cargo fmt
+        run: cargo fmt --all -- --check
+
+  test:
+    name: 🧪 Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛎️ Checkout
+        uses: actions/checkout@v5
+
+      - name: 📦 Cargo version
+        id: cargo
+        run: |
+          echo "rustc=$(rustc --version)" >> "${GITHUB_OUTPUT}"
+
+      - name: 🪣 Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          key: ${{ steps.cargo.outputs.rustc }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ steps.cargo.outputs.rustc }}
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+
+      - name: 📎 Cargo clippy
+        run: |
+          cargo clippy --release -- -D warnings
+
+      - name: 🔨 Cargo test
+        run: |
+          cargo test --release


### PR DESCRIPTION
## Summary
- New `test.yml` (fmt + clippy + test) — runs on `pull_request` and exposes `workflow_call`
- New `build.yml` (multi-arch image matrix) — runs on `pull_request` (validation, no push) and exposes `workflow_call` with a `push` input
- `release.yml` is now a tag-push-only orchestrator that calls `test.yml` and `build.yml` (with `push: true`), then assembles the manifest list and publishes the GitHub release

## Test plan
- [ ] `test.yml` runs and passes on this PR
- [ ] `build.yml` runs the PR-validation build on both `linux/amd64` and `linux/arm64` without pushing
- [ ] Next tag push triggers `release.yml`, which runs test + build (push:true) → merge → release end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)