### PR TITLE
Register bots create/delete in the OpenAPI

### DIFF
--- a/api/src/routes/v2/bots.rs
+++ b/api/src/routes/v2/bots.rs
@@ -136,6 +136,6 @@ async fn delete(identity: ApiIdentity, id: web::Path<Uuid>) -> ApiResult {
         name = "Bots",
         description = "This collection contains all bots in Platz.",
     )),
-    paths(get_all, get_one, update),
+    paths(get_all, get_one, create, update, delete),
 )]
 pub(super) struct OpenApi;


### PR DESCRIPTION
The bots `OpenApi` derive only listed `paths(get_all, get_one, update)`, so the `POST /bots` (`createBot`) and `DELETE /bots/{id}` (`deleteBot`) operations — and the `NewBot` request-body schema — were missing from the generated `openapi.yaml`, and thus from the generated JS SDK (`@platzio/sdk`).

This regressed the frontend's bot-creation form, which imports `NewBot` from `@platzio/sdk`. Peer collections (`secrets`, `envs`) already register the full `get_all, get_one, create, update, delete` set; this brings `bots` in line.

Verified locally: `platz-api openapi schema` now emits `NewBot` and the `createBot`/`deleteBot` operations; the component-schema set is otherwise unchanged from v0.7.0-beta.2 (only `NewBot` added, nothing dropped).

Required to cut `v0.7.0-beta.4`.