### PR TITLE
Inherit crate version from [workspace.package]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,13 @@ members = [
 ]
 resolver = "2"
 
+# Shared package metadata inherited by every workspace member via
+# `version.workspace = true`. Bumping the release version is a single edit
+# here (or `cargo set-version --workspace <VER>`), which keeps all crates —
+# and the OpenAPI `info.version` derived from the api crate — in lockstep.
+[workspace.package]
+version = "0.1.0"
+
 [profile.release]
 debug = true
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "platz-api"
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 actix = "0.13.5"

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "platz-auth"
-version = "0.1.0"
+version.workspace = true
 
 [features]
 actix = ["actix-web", "actix-web-httpauth", "futures"]

--- a/chart-discovery/Cargo.toml
+++ b/chart-discovery/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "platz-chart-discovery"
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 anyhow = "1.0.102"

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "platz-db"
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 anyhow = "1.0.102"

--- a/k8s-agent/Cargo.toml
+++ b/k8s-agent/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "platz-k8s-agent"
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 anyhow = { version = "1.0.102", features = ["backtrace"] }

--- a/otel/Cargo.toml
+++ b/otel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "platz-otel"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [dependencies]

--- a/resource-sync/Cargo.toml
+++ b/resource-sync/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "platz-resource-sync"
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 anyhow = "1.0.102"

--- a/status-updates/Cargo.toml
+++ b/status-updates/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "platz-status-updates"
-version = "0.1.0"
+version.workspace = true
 
 [dependencies]
 anyhow = "1.0.102"


### PR DESCRIPTION
## What

Move the crate version to `[workspace.package]` and have every member crate inherit it with `version.workspace = true`, instead of each manifest hard-coding its own `version`.

## Why

All eight workspace members carried their own `version = "0.1.0"`, so bumping the release version meant editing eight manifests — and in practice it never happened, leaving every crate at `0.1.0`. Since `utoipa` derives the OpenAPI `info.version` from the `api` crate's `CARGO_PKG_VERSION`, that stale `0.1.0` propagated into the published `openapi.yaml`, the rendered API reference on the docs site, and the generated SDKs.

With this change, releasing bumps the version in **one** place — `[workspace.package].version` — or via `cargo set-version --workspace <VER>`, keeping all crates and the OpenAPI version in lockstep. This pairs with the release-runbook fix in [platzio/dev#6](https://github.com/platzio/dev/pull/6).

## Note

The version is **intentionally left at `0.1.0`** here — no bump. The next release will set it through the workspace key (a release is planned right after this merges). Inter-crate dependencies are path-only (no version pins), so nothing else needed touching, and `Cargo.lock` is unchanged.

## Verification

`cargo metadata --no-deps` resolves all eight crates at `0.1.0` through the workspace, confirming the inheritance is wired correctly:

```
platz-api 0.1.0
platz-auth 0.1.0
platz-chart-discovery 0.1.0
platz-db 0.1.0
platz-k8s-agent 0.1.0
platz-otel 0.1.0
platz-resource-sync 0.1.0
platz-status-updates 0.1.0
```

https://claude.ai/code/session_012x3qrx2pZ4HtbhJPB6W5Zv

---
_Generated by [Claude Code](https://claude.ai/code/session_012x3qrx2pZ4HtbhJPB6W5Zv)_