### PR TITLE
v0.7.0-beta.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3196,7 +3196,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "platz-api"
-version = "0.1.0"
+version = "0.7.0-beta.5"
 dependencies = [
  "actix",
  "actix-web",
@@ -3230,7 +3230,7 @@ dependencies = [
 
 [[package]]
 name = "platz-auth"
-version = "0.1.0"
+version = "0.7.0-beta.5"
 dependencies = [
  "actix-web",
  "actix-web-httpauth",
@@ -3254,7 +3254,7 @@ dependencies = [
 
 [[package]]
 name = "platz-chart-discovery"
-version = "0.1.0"
+version = "0.7.0-beta.5"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "platz-db"
-version = "0.1.0"
+version = "0.7.0-beta.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3338,7 +3338,7 @@ dependencies = [
 
 [[package]]
 name = "platz-k8s-agent"
-version = "0.1.0"
+version = "0.7.0-beta.5"
 dependencies = [
  "anyhow",
  "aws-arn",
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "platz-otel"
-version = "0.1.0"
+version = "0.7.0-beta.5"
 dependencies = [
  "anyhow",
  "tracing-subscriber",
@@ -3387,7 +3387,7 @@ dependencies = [
 
 [[package]]
 name = "platz-resource-sync"
-version = "0.1.0"
+version = "0.7.0-beta.5"
 dependencies = [
  "anyhow",
  "platz-chart-ext",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "platz-status-updates"
-version = "0.1.0"
+version = "0.7.0-beta.5"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ resolver = "2"
 # here (or `cargo set-version --workspace <VER>`), which keeps all crates —
 # and the OpenAPI `info.version` derived from the api crate — in lockstep.
 [workspace.package]
-version = "0.1.0"
+version = "0.7.0-beta.5"
 
 [profile.release]
 debug = true


### PR DESCRIPTION
Bump the workspace version to the release version for **v0.7.0-beta.5** (single-line edit via the `[workspace.package].version` key added in #106; refreshes `Cargo.lock`). All eight crates now report `0.7.0-beta.5` (`cargo metadata` verified), so the OpenAPI `info.version` and the docs API reference will finally track the real release.

Part of cutting **v0.7.0-beta.5**. (This commit would normally be pushed straight to `main` by the release runbook, but direct pushes to `main` are blocked in this environment — hence the PR.)

https://claude.ai/code/session_012x3qrx2pZ4HtbhJPB6W5Zv

---
_Generated by [Claude Code](https://claude.ai/code/session_012x3qrx2pZ4HtbhJPB6W5Zv)_