### PR TITLE
Switch free-disk-space action to jlumbroso/free-disk-space@v1.3.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 🗽 Free disk space
-        uses: ShubhamTatvamasi/free-disk-space-action@master
+        uses: jlumbroso/free-disk-space@v1.3.1
 
       - name: 🐳 Login to DockerHub
         if: inputs.push


### PR DESCRIPTION
The previous action — `ShubhamTatvamasi/free-disk-space-action@master` — has two problems:

- **Pinned to a floating `@master` ref** (supply-chain risk; CodeQL would flag it).
- **Unmaintained**: its repo has had no commits since April 2022, with only a single 1.0.0 release from that same month.

Switching to **[`jlumbroso/free-disk-space`](https://github.com/jlumbroso/free-disk-space)** at the pinned `v1.3.1` tag:

|  | current | new |
|---|---|---|
| ref | `@master` (floating) | `@v1.3.1` (pinned) |
| last push | April 2022 | August 2024 |
| stars | very low | 687 |

The cleanup is still needed — backend's multi-arch `linux/amd64 + linux/arm64` build fills the runner disk, and dropping the step would risk surfacing as a release-CI failure after a ~20-minute build. `jlumbroso/free-disk-space` is the de-facto standard alternative, used by a huge fraction of multi-arch Docker workflows, and a drop-in replacement here (current usage has no flags; v1.3.1's defaults free ~30 GB the same way).

Follow-up flagged in PR #107 (the pre-release dep refresh).

https://claude.ai/code/session_012x3qrx2pZ4HtbhJPB6W5Zv